### PR TITLE
feat: Implement server ping monitor worker

### DIFF
--- a/migrations/0001_create_server_status_table.sql
+++ b/migrations/0001_create_server_status_table.sql
@@ -1,0 +1,10 @@
+-- Create the server_status table
+-- To apply this migration, use the following Wrangler command:
+-- wrangler d1 execute <YOUR_DB_NAME> --file=./migrations/0001_create_server_status_table.sql
+
+CREATE TABLE IF NOT EXISTS server_status (
+  server_name TEXT PRIMARY KEY,
+  last_hello_timestamp INTEGER DEFAULT 0,
+  last_state TEXT CHECK(last_state IN ('up', 'down')) DEFAULT 'down',
+  last_state_change_timestamp INTEGER DEFAULT 0
+);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "server-ping-monitor",
+  "version": "1.0.0",
+  "description": "Cloudflare Worker to monitor server pings and send Telegram notifications.",
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "echo \"Error: no test specified yet\" && exit 1",
+    "migrate:local": "wrangler d1 execute <YOUR_DB_NAME> --local --file=./migrations/0001_create_server_status_table.sql",
+    "migrate:prod": "wrangler d1 execute <YOUR_DB_NAME> --file=./migrations/0001_create_server_status_table.sql"
+  },
+  "keywords": [
+    "cloudflare-worker",
+    "server-monitor",
+    "telegram",
+    "d1"
+  ],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20231025.0",
+    "typescript": "^5.2.2",
+    "wrangler": "^3.15.0"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,160 @@
+import { Env, ServerStatus } from './types';
+import { sendTelegramMessage } from './telegram';
+
+// Helper to parse query parameters
+function getQueryParam(url: string, param: string): string | null {
+  const params = new URL(url).searchParams;
+  return params.get(param);
+}
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.method === 'POST' && url.pathname === '/hello') {
+      // 1. Authenticate
+      const authHeader = request.headers.get('Authorization');
+      if (!authHeader || !authHeader.startsWith('Bearer ')) {
+        return new Response('Unauthorized: Missing or invalid Authorization header', { status: 401 });
+      }
+      const token = authHeader.substring('Bearer '.length);
+      if (token !== env.ACCESS_TOKEN) {
+        return new Response('Unauthorized: Invalid token', { status: 401 });
+      }
+
+      // 2. Validate server_name
+      const serverName = getQueryParam(request.url, 'server_name');
+      if (!serverName) {
+        return new Response('Bad Request: Missing server_name query parameter', { status: 400 });
+      }
+
+      const allowedServers = env.SERVERS.split(',').map(s => s.trim());
+      if (!allowedServers.includes(serverName)) {
+        return new Response(`Bad Request: Invalid server_name '${serverName}'. Allowed: ${allowedServers.join(', ')}`, { status: 400 });
+      }
+
+      const currentTime = Math.floor(Date.now() / 1000);
+
+      try {
+        // 3. Get current status from D1
+        let serverInfo: ServerStatus | null = await env.DB.prepare(
+          "SELECT server_name, last_hello_timestamp, last_state, last_state_change_timestamp FROM server_status WHERE server_name = ?"
+        ).bind(serverName).first();
+
+        if (serverInfo) {
+          // Server exists in DB
+          const previousState = serverInfo.last_state;
+          serverInfo.last_hello_timestamp = currentTime;
+          serverInfo.last_state = 'up';
+
+          if (previousState === 'down') {
+            const downTimeSeconds = currentTime - serverInfo.last_state_change_timestamp;
+            const downTimeMinutes = Math.round(downTimeSeconds / 60);
+            const downTimeDuration = downTimeSeconds < 60 ? `${downTimeSeconds}s` : `${downTimeMinutes}min`;
+
+            serverInfo.last_state_change_timestamp = currentTime;
+            // Update D1
+            await env.DB.prepare(
+              "UPDATE server_status SET last_hello_timestamp = ?, last_state = ?, last_state_change_timestamp = ? WHERE server_name = ?"
+            ).bind(
+              serverInfo.last_hello_timestamp,
+              serverInfo.last_state,
+              serverInfo.last_state_change_timestamp,
+              serverName
+            ).run();
+
+            // Send notification
+            const message = `✅ Server *${serverName}* is back UP.\nIt was down for approximately ${downTimeDuration}.`;
+            ctx.waitUntil(sendTelegramMessage(env, message));
+            console.log(`Notification sent: ${serverName} is UP after being down for ${downTimeDuration}.`);
+            return new Response(`Hello received for ${serverName}. Server is now UP. Downtime was ${downTimeDuration}.`, { status: 200 });
+          } else {
+            // Still up, just update hello time
+            await env.DB.prepare(
+              "UPDATE server_status SET last_hello_timestamp = ? WHERE server_name = ?"
+            ).bind(serverInfo.last_hello_timestamp, serverName).run();
+            console.log(`Hello received for ${serverName}. Status remains UP.`);
+            return new Response(`Hello received for ${serverName}. Status remains UP.`, { status: 200 });
+          }
+        } else {
+          // New server, first time hello
+          serverInfo = {
+            server_name: serverName,
+            last_hello_timestamp: currentTime,
+            last_state: 'up',
+            last_state_change_timestamp: currentTime,
+          };
+          await env.DB.prepare(
+            "INSERT INTO server_status (server_name, last_hello_timestamp, last_state, last_state_change_timestamp) VALUES (?, ?, ?, ?)"
+          ).bind(
+            serverInfo.server_name,
+            serverInfo.last_hello_timestamp,
+            serverInfo.last_state,
+            serverInfo.last_state_change_timestamp
+          ).run();
+          const message = `👋 Server *${serverName}* sent its first ping and is now marked UP.`;
+          ctx.waitUntil(sendTelegramMessage(env, message));
+          console.log(`Notification sent: ${serverName} is newly UP.`);
+          return new Response(`Hello received for new server ${serverName}. Marked as UP.`, { status: 201 });
+        }
+      } catch (e: any) {
+        console.error('D1 Error in /hello:', e.message, e.cause);
+        return new Response(`Database error: ${e.message}`, { status: 500 });
+      }
+    }
+
+    if (url.pathname === '/') {
+      return new Response('Server Ping Monitor is running. Use POST /hello?server_name=<name> to report.', { status: 200 });
+    }
+
+    return new Response('Not found.', { status: 404 });
+  },
+
+  async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
+    console.log(`Scheduled task running at ${new Date().toISOString()}`);
+    const serverNamesFromEnv = env.SERVERS.split(',').map(s => s.trim()).filter(s => s.length > 0);
+    const currentTime = Math.floor(Date.now() / 1000);
+    const alertThresholdSeconds = 70; // Consider a server down if no hello for > 70 seconds (to allow for slight delays)
+
+    for (const serverName of serverNamesFromEnv) {
+      try {
+        let serverInfo: ServerStatus | null = await env.DB.prepare(
+          "SELECT server_name, last_hello_timestamp, last_state, last_state_change_timestamp FROM server_status WHERE server_name = ?"
+        ).bind(serverName).first();
+
+        if (serverInfo) {
+          // Server exists in DB
+          if (serverInfo.last_state === 'up' && (currentTime - serverInfo.last_hello_timestamp > alertThresholdSeconds)) {
+            // Server was 'up' but missed pings, mark as 'down'
+            console.log(`Server ${serverName} missed pings. Last hello: ${serverInfo.last_hello_timestamp}, Current time: ${currentTime}`);
+            await env.DB.prepare(
+              "UPDATE server_status SET last_state = 'down', last_state_change_timestamp = ? WHERE server_name = ?"
+            ).bind(currentTime, serverName).run();
+
+            const message = `❗ Server *${serverName}* is DOWN. No ping received for over ${alertThresholdSeconds} seconds.`;
+            ctx.waitUntil(sendTelegramMessage(env, message));
+            console.log(`Notification sent: ${serverName} is DOWN.`);
+          }
+          // If serverInfo.last_state is 'down', we wait for a /hello to mark it up.
+          // If serverInfo.last_state is 'up' and last_hello_timestamp is recent, do nothing.
+        } else {
+          // Server is in ENV but not in DB, this is the first time we're noticing it (or it was deleted from DB)
+          // Add it as 'down' and notify.
+          console.log(`Server ${serverName} from ENV not found in DB. Adding as 'down'.`);
+          await env.DB.prepare(
+            "INSERT INTO server_status (server_name, last_hello_timestamp, last_state, last_state_change_timestamp) VALUES (?, ?, ?, ?)"
+          ).bind(serverName, 0, 'down', currentTime).run(); // last_hello_timestamp as 0 or currentTime
+
+          const message = `❓ Server *${serverName}* is configured but has not reported any status. Marking as DOWN.`;
+          ctx.waitUntil(sendTelegramMessage(env, message));
+          console.log(`Notification sent: ${serverName} is newly marked as DOWN (not found in DB).`);
+        }
+      } catch (e: any) {
+        console.error(`Error processing server ${serverName} in scheduled task:`, e.message, e.cause);
+        // Optionally send a Telegram message about the error itself if it's critical
+        // ctx.waitUntil(sendTelegramMessage(env, `Worker error processing ${serverName}: ${e.message}`));
+      }
+    }
+    console.log('Scheduled task finished.');
+  }
+};

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -1,0 +1,30 @@
+import { Env } from './types';
+
+export async function sendTelegramMessage(env: Env, message: string): Promise<Response> {
+  const telegramApiUrl = `https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/sendMessage`;
+  const payload = {
+    chat_id: env.TELEGRAM_CHAT_ID,
+    text: message,
+    parse_mode: 'Markdown', // Optional: for formatting like bold, italic
+  };
+
+  try {
+    const response = await fetch(telegramApiUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      console.error(`Telegram API error: ${response.status} ${response.statusText}`, errorData);
+      return new Response(`Telegram API error: ${errorData}`, { status: response.status });
+    }
+    return response;
+  } catch (error) {
+    console.error('Failed to send Telegram message:', error);
+    return new Response(`Failed to send Telegram message: ${error}`, { status: 500 });
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,17 @@
+export interface Env {
+  // Environment variables
+  SERVERS: string; // Comma-separated list of server hostnames
+  TELEGRAM_BOT_TOKEN: string;
+  TELEGRAM_CHAT_ID: string;
+  ACCESS_TOKEN: string;
+
+  // D1 Binding
+  DB: D1Database;
+}
+
+export interface ServerStatus {
+  server_name: string;
+  last_hello_timestamp: number; // Unix timestamp (seconds)
+  last_state: 'up' | 'down';
+  last_state_change_timestamp: number; // Unix timestamp (seconds)
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "lib": ["esnext", "dom"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,59 @@
+name = "server-ping-monitor"
+main = "src/index.ts"
+compatibility_date = "2023-10-30" # Or a more recent date
+
+# Cron trigger to run the scheduled task every minute
+triggers = [
+  { cron = "*/1 * * * *" }
+]
+
+# D1 database binding
+# Replace 'YOUR_D1_DATABASE_ID' with your actual D1 database ID.
+# You can create a D1 database using: wrangler d1 create <YOUR_DB_NAME>
+# And then find its ID in the .wrangler/state/v3/d1 directory or via `wrangler d1 info <YOUR_DB_NAME>`
+[[d1_databases]]
+binding = "DB" # This is how it's accessed in the Env interface (env.DB)
+database_name = "<YOUR_DB_NAME>" # Give your database a descriptive name
+database_id = "<YOUR_D1_DATABASE_ID>" # The actual ID of your D1 instance
+
+# Environment variables
+# These should be set in your Cloudflare dashboard or using `wrangler secret put VAR_NAME`
+# For local development, you can create a .dev.vars file (make sure it's in .gitignore)
+# Example .dev.vars content:
+# SERVERS="example.com,sub.example.com"
+# TELEGRAM_BOT_TOKEN="your_telegram_bot_token"
+# TELEGRAM_CHAT_ID="your_telegram_chat_id"
+# ACCESS_TOKEN="your_secure_access_token"
+
+[vars]
+# Default values (consider if these are safe as defaults or should only be secrets)
+# It's generally better to manage sensitive data like tokens via secrets.
+# SERVERS = "example.com" # Example, will be overridden by secrets or .dev.vars
+# TELEGRAM_BOT_TOKEN = "dummy_token"
+# TELEGRAM_CHAT_ID = "dummy_chat_id"
+# ACCESS_TOKEN = "dummy_access_token"
+
+# It is highly recommended to use secrets for sensitive data:
+# wrangler secret put SERVERS
+# wrangler secret put TELEGRAM_BOT_TOKEN
+# wrangler secret put TELEGRAM_CHAT_ID
+# wrangler secret put ACCESS_TOKEN
+
+# For local development with `wrangler dev --local`, create a .dev.vars file.
+# Ensure .dev.vars is in your .gitignore file.
+#
+# .dev.vars example:
+# SERVERS="server1.example.com,server2.example.com"
+# TELEGRAM_BOT_TOKEN="xxxxxxxxx:xxxxxxxxxxxxxxxxxxxxxxxxxxx"
+# TELEGRAM_CHAT_ID="123456789"
+# ACCESS_TOKEN="a_very_secure_bearer_token_here"
+# DB_BINDING_NAME_FOR_DEV_VARS_ONLY = "<YOUR_DB_NAME>" # This is only for wrangler dev --local to pick up the local DB. It's not a standard var.
+# The actual binding for `env.DB` is configured via [[d1_databases]] above.
+# When running `wrangler dev --local`, wrangler will automatically create a local .wrangler/state/v3/d1/<YOUR_DB_NAME>-<ID>.sqlite file if it doesn't exist,
+# based on the database_name in the [[d1_databases]] section.
+# You'll need to run your migrations against this local DB:
+# wrangler d1 execute <YOUR_DB_NAME> --local --file=./migrations/0001_create_server_status_table.sql
+
+# Enable node_compat for better compatibility if using Node.js APIs explicitly
+# (though for this worker, it's likely not strictly needed yet)
+# node_compat = true


### PR DESCRIPTION
Implements a Cloudflare Worker to receive server pings, track server status (up/down) in D1, and send Telegram notifications on state changes.

Features:
- Typescript implementation.
- Configurable via environment variables (SERVERS, TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID, ACCESS_TOKEN).
- `/hello` endpoint for servers to report pings, requiring bearer token authentication and valid server_name.
- D1 database stores last_hello_timestamp, last_state, and last_state_change_timestamp.
- Notifications sent via Telegram when a server goes down or comes back up (reporting downtime).
- Scheduled task (cron every 1 minute) to detect missed pings and mark servers as down.
- Handles new servers and servers listed in ENV but not yet in DB.