### PR TITLE
Refactor: use itty-router to manage http request routering

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   ],
   "author": "",
   "license": "MIT",
+  "dependencies": {
+    "itty-router": "^4.0.23"
+  },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20231025.0",
     "typescript": "^5.2.2",


### PR DESCRIPTION
Refactor: Introduce itty-router for Express-like structure

Refactored the Cloudflare Worker to use `itty-router` for improved readability and organization.

Key changes:
- Added `itty-router` dependency.
- Implemented routing `/hello` endpoints.
- Extracted authentication and `server_name` validation into middleware functions.
- Maintained the functionality of the `fetch` and `scheduled` handlers.
- Ensured `types.ts` and `telegram.ts` remain compatible.